### PR TITLE
derive copy, clone for candles

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -17,7 +17,7 @@ pub struct GetPriceHistoryResponse {
 }
 
 /// Individual candle item in [`GetPriceHistoryResponse`](struct.GetPriceHistoryResponse.html).
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Candle {
     pub close: f64,
     pub datetime: usize,

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -17,7 +17,7 @@ pub struct GetPriceHistoryResponse {
 }
 
 /// Individual candle item in [`GetPriceHistoryResponse`](struct.GetPriceHistoryResponse.html).
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 pub struct Candle {
     pub close: f64,
     pub datetime: usize,


### PR DESCRIPTION
Greetings,

In using this library and handling candle data, I've found it helpful to have the Clone and copy traits derived.

If it makes sense to add a test case for this, I'd be happy too, but my rudimentary understanding of Rust's traits and derives suggest this wouldn't be of much value. Please let me know if I'm mistaken.